### PR TITLE
Added basic input argument parser to support MSBuildPath and Solution

### DIFF
--- a/SolutionAnalyzer.Test/Properties/AssemblyInfo.cs
+++ b/SolutionAnalyzer.Test/Properties/AssemblyInfo.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("SolutionAnalyzer.Test")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SolutionAnalyzer.Test")]
+[assembly: AssemblyCopyright("Copyright ©  2022")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+[assembly: ComVisible(false)]
+
+[assembly: Guid("e051da41-6d08-4cc2-9cd8-a97fdb00101a")]
+
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SolutionAnalyzer.Test/SolutionAnalyzer.Test.csproj
+++ b/SolutionAnalyzer.Test/SolutionAnalyzer.Test.csproj
@@ -1,0 +1,68 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E051DA41-6D08-4CC2-9CD8-A97FDB00101A}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SolutionAnalyzer.Test</RootNamespace>
+    <AssemblyName>SolutionAnalyzer.Test</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.2.7\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.2.7\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="UnitTest1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.2.2.7\build\net45\MSTest.TestAdapter.targets')" />
+</Project>

--- a/SolutionAnalyzer.Test/UnitTest1.cs
+++ b/SolutionAnalyzer.Test/UnitTest1.cs
@@ -1,0 +1,14 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace SolutionAnalyzer.Test
+{
+    [TestClass]
+    public class UnitTest1
+    {
+        [TestMethod]
+        public void TestMethod1()
+        {
+        }
+    }
+}

--- a/SolutionAnalyzer.Test/packages.config
+++ b/SolutionAnalyzer.Test/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="2.2.7" targetFramework="net472" />
+  <package id="MSTest.TestFramework" version="2.2.7" targetFramework="net472" />
+</packages>

--- a/SolutionAnalyzer.sln
+++ b/SolutionAnalyzer.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.1.32328.378
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SolutionAnalyzer", "SolutionAnalyzer\SolutionAnalyzer.csproj", "{43543F2B-3563-49BF-BEBB-22CC470E6438}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SolutionAnalyzer", "SolutionAnalyzer\SolutionAnalyzer.csproj", "{43543F2B-3563-49BF-BEBB-22CC470E6438}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SolutionAnalyzer.Test", "SolutionAnalyzer.Test\SolutionAnalyzer.Test.csproj", "{E051DA41-6D08-4CC2-9CD8-A97FDB00101A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{43543F2B-3563-49BF-BEBB-22CC470E6438}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{43543F2B-3563-49BF-BEBB-22CC470E6438}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{43543F2B-3563-49BF-BEBB-22CC470E6438}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E051DA41-6D08-4CC2-9CD8-A97FDB00101A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E051DA41-6D08-4CC2-9CD8-A97FDB00101A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E051DA41-6D08-4CC2-9CD8-A97FDB00101A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E051DA41-6D08-4CC2-9CD8-A97FDB00101A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SolutionAnalyzer/CommandArgumentOptions.cs
+++ b/SolutionAnalyzer/CommandArgumentOptions.cs
@@ -1,0 +1,18 @@
+﻿using CommandLine;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SolutionAnalyzer
+{
+    internal class CommandArgumentOptions
+    {
+        [Option('b', "ms-build-path", Required = true, HelpText = "Path to a Visual Studio MSBuild toolset.")]
+        public string VisualStudioMSBuildPath { get; set; }
+
+        [Option('s', "solution-path", Required = true, HelpText = "Path to the solution to be analyzed.")]
+        public string SolutionPath { get; set; }
+    }
+}

--- a/SolutionAnalyzer/CommandArgumentParser.cs
+++ b/SolutionAnalyzer/CommandArgumentParser.cs
@@ -1,0 +1,35 @@
+﻿
+using CommandLine;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SolutionAnalyzer
+{
+    internal class CommandArgumentParser
+    {
+        public string VisualStudioMSBuildPath { get; set; }
+        public string SolutionPath { get; set; }
+
+        public bool HandleCommand(string[] args)
+        {
+            var result = Parser.Default
+                .ParseArguments<CommandArgumentOptions>(args)
+                .WithParsed<CommandArgumentOptions>(o =>
+                {
+                    VisualStudioMSBuildPath = o.VisualStudioMSBuildPath;
+                    
+                    if (!string.IsNullOrEmpty(o.SolutionPath) &&
+                        File.Exists(o.SolutionPath))
+                    {
+                        SolutionPath = o.SolutionPath;
+                    }
+                });
+
+            return (result.Tag != ParserResultType.NotParsed);
+        }
+    }
+}

--- a/SolutionAnalyzer/Properties/launchSettings.json
+++ b/SolutionAnalyzer/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "SolutionAnalyzer": {
       "commandName": "Project",
-      "commandLineArgs": "D:\\work\\TestProjects"
+      "commandLineArgs": "-b \"C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\" -s \"D:\\work\\TestProjects\\net472\\Community-Medicine-System\\CommunityMedicineSystem.sln\""
     }
   }
 }

--- a/SolutionAnalyzer/SolutionAnalyzer.cs
+++ b/SolutionAnalyzer/SolutionAnalyzer.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.MSBuild;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SolutionAnalyzer
+{
+    internal class ConsoleProgressReporter : IProgress<ProjectLoadProgress>
+    {
+        public void Report(ProjectLoadProgress loadProgress)
+        {
+            var projectDisplay = Path.GetFileName(loadProgress.FilePath);
+            if (loadProgress.TargetFramework != null)
+            {
+                projectDisplay += $" ({loadProgress.TargetFramework})";
+            }
+
+            Console.WriteLine($"{loadProgress.Operation,-15} {loadProgress.ElapsedTime,-15:m\\:ss\\.fffffff} {projectDisplay}");
+        }
+    }
+
+    internal class SolutionAnalyzer
+    {
+        public static Task<Solution> AnalyzeSolution(string solutionPath)
+        {
+            using (var workspace = MSBuildWorkspace.Create())
+            {
+                // Print message for WorkspaceFailed event to help diagnosing project load failures.
+                workspace.WorkspaceFailed += (o, e) => Console.WriteLine(e.Diagnostic.Message);
+
+                // Attach progress reporter so we print projects as they are loaded.
+                return workspace.OpenSolutionAsync(solutionPath, new ConsoleProgressReporter());
+            }
+        }
+    }
+}

--- a/SolutionAnalyzer/SolutionAnalyzer.csproj
+++ b/SolutionAnalyzer/SolutionAnalyzer.csproj
@@ -6,6 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="..\nuget.exe" Link="nuget.exe">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.1.0" />

--- a/SolutionAnalyzer/Utilities.cs
+++ b/SolutionAnalyzer/Utilities.cs
@@ -1,0 +1,71 @@
+﻿using Microsoft.Build.Locator;
+using Microsoft.CodeAnalysis;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SolutionAnalyzer
+{
+    internal class Utilities
+    {
+        public static bool RegisterVisualStudioInstance(CommandArgumentParser parser)
+        {
+            // Enumerate valid visual studio instances.
+            var visualStudioInstances = MSBuildLocator.QueryVisualStudioInstances().ToArray();
+            
+            // Find the valid one from user input.
+            foreach (var visualStudioInstance in visualStudioInstances)
+            {
+                if (visualStudioInstance != null && 
+                    visualStudioInstance.MSBuildPath.Contains(parser.VisualStudioMSBuildPath))
+                {
+                    MSBuildLocator.RegisterInstance(visualStudioInstance);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public static bool IsSolutionFileValid(string solutionPath)
+        {
+            return (!string.IsNullOrEmpty(solutionPath) && File.Exists(solutionPath));
+        }
+
+        public static void RestorePackages(string solutionPath)
+        {
+            using (Process process = new Process())
+            {
+                process.StartInfo = new ProcessStartInfo
+                {
+                    FileName = @"nuget.exe",
+                    Arguments = $"restore {solutionPath} -Verbosity quiet",
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+
+                process.Start();
+                process.WaitForExit();
+            }
+        }
+
+        public static void PrintDependencies(Project project)
+        {
+            if (project != null)
+            {
+                Console.WriteLine();
+                Console.WriteLine($"{project.Name}:");
+                var dependencies = project?.MetadataReferences;
+
+                foreach (var dependency in dependencies)
+                {
+                    Console.WriteLine(dependency.Display);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Basic input argument support for:
-b : MSBuildPath
-s : SolutionPath
Output the dependencies of each project onto command line screen.

Some simple validation regarding MSBuildPath and SolutionPath.
TODO:

Add some unit test for better solid implementations.